### PR TITLE
Update qwesty.ino

### DIFF
--- a/qwesty.ino
+++ b/qwesty.ino
@@ -125,7 +125,7 @@ void loop() {
       sendNoteOff(note);
       state.heldNotes[note] = false;
     }
-
+    
     return;
   }
 
@@ -150,8 +150,12 @@ void loop() {
     keyboard.setLock(PS2_LOCK_NUM);
     state.root = 9;
   }
+  
+// to prevent taxing the device, only update LCD on octave/root/scale change 
+  if (isRoot(keyCode) || isScale(keyCode) ||  isOctave(keyCode)) {
+     lcdPrint(keyCode);
+   }
 
-  lcdPrint(keyCode);
 }
 
 int8_t getKeyIndex(uint8_t keyCode) {


### PR DESCRIPTION
Turns out updating the LCD on every loop breaks the ability to send chords.

Chris and I investigated only outputting to LCD on octave, scale, and root changes. He tested a slightly different change (in the keyup block --- but that's a poor place for it from a readability standpoint and didn't address the other issue Chris was encountering (see below), so putting the lcdprint statement inside a conditional check. 

This did solve the main problem --- Chris was able to make chords and see the LCD update --- but there's still a lingering issue. When holding down multiple keys and changing root/octave/scale, notes will be stuck.  Need a different fix for that.